### PR TITLE
Postman collection creation fixes minus the formatting

### DIFF
--- a/src/ProcessGpcAcceptanceTestData.js
+++ b/src/ProcessGpcAcceptanceTestData.js
@@ -394,11 +394,12 @@ async function processGpcAcceptanceTestData(
           )
           .join('\n');
 
+        // TEMP COMMENT OUT AS CAUSES DOWNSTREAM ISSUES IN WIREMOCK
         // Replace empty requestParameters tag with populated one
-        xmlContent = xmlContent.replace(
-          /<requestParameters\s*\/>/,
-          `<requestParameters>\n${queryParamsXml}\n    </requestParameters>`
-        );
+        // xmlContent = xmlContent.replace(
+        //     /<requestParameters\s*\/>/,
+        //     `<requestParameters>\n${queryParamsXml}\n    </requestParameters>`
+        // );
 
         // Write the updated XML back to the file
         console.log(


### PR DESCRIPTION
fixes for the following issues:

in src/CreateCollection.js:

1. retain the protocol into the postman collection (ie http or https)
2. retain the requestURL on the end of the endpoint url (ie 'Appointment/110' retained on the end of the url)
3. retain the Content-Type header in the request headers
4. do not add _ prefixed query parameters to the requests

in src/ProcessGpcAcceptanceTestData.js:

1. request parameters no longer added from ConsoleLog.txt file if requestParameters is an empty tag in request